### PR TITLE
add support for h3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A modern, lightweight, interactive web-based geospatial data viewer built with R
 - 📍 Support for multiple data formats:
   - GeoJSON files for polygon/line/point data
   - CSV files with coordinate data (auto-detects lat/long columns)
+  - CSV files with H3 hexagon indices
 - 🎨 Interactive styling options:
   - Color picker for layers
   - Opacity control
@@ -39,6 +40,24 @@ A modern, lightweight, interactive web-based geospatial data viewer built with R
   - Feature property inspection
   - Column selection for display
   - Advanced filtering options
+
+## Data Format Requirements
+
+### GeoJSON
+- Standard GeoJSON format with Feature Collection
+- Properties will be available for filtering and display
+
+### CSV (Points)
+- Must include coordinate columns with one of these naming patterns:
+  - Latitude: `lat`, `latitude`, or `y`
+  - Longitude: `lng`, `long`, `longitude`, or `x`
+- Additional columns will be available as properties
+
+### CSV (H3 Hexagons)
+- Must include an H3 index column with one of these names:
+  - `hex_id`, `h3_index`, `h3`, or `hexagon`
+- H3 indices must be valid H3 cell addresses
+- Additional columns will be available as properties
 
 ## Usage
 1. Clone the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@arcgis/core": "^4.32.9",
         "@deck.gl/core": "^9.1.5",
+        "@deck.gl/geo-layers": "^9.1.6",
         "@deck.gl/layers": "^9.1.5",
         "@deck.gl/react": "^9.1.5",
         "@deck.gl/widgets": "^9.1.5",
@@ -19,11 +20,10 @@
         "@luma.gl/core": "^9.0.0",
         "@luma.gl/engine": "^9.0.0",
         "@luma.gl/shadertools": "^9.0.0",
-        "@types/papaparse": "^5.3.15",
         "deck.gl": "^9.1.5",
         "geojson": "^0.5.0",
+        "h3-js": "^4.1.0",
         "mapbox-gl": "^2.15.0",
-        "papaparse": "^5.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-map-gl": "^7.1.6"
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.5.tgz",
-      "integrity": "sha512-pkqjJW2zF08VH4XH/sHIFwYwAjLeyKa/J5M8sza/VKjaJdcpvktlT/52VqR/4P6IECF4FS6LUNcsBMiiYRoTRw==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.6.tgz",
+      "integrity": "sha512-pacef6yKJADZ55oyIPbCHmDWVGSIQpwBiSlAGqiP7m1jWGYsPY6/tHVWHhrbb+Hood7yT4necMum4c6W8S/OGQ==",
       "license": "MIT",
       "dependencies": {
         "@loaders.gl/3d-tiles": "^4.2.0",
@@ -567,8 +567,8 @@
         "@loaders.gl/terrain": "^4.2.0",
         "@loaders.gl/tiles": "^4.2.0",
         "@loaders.gl/wms": "^4.2.0",
-        "@luma.gl/gltf": "^9.1.3",
-        "@luma.gl/shadertools": "^9.1.3",
+        "@luma.gl/gltf": "^9.1.5",
+        "@luma.gl/shadertools": "^9.1.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
@@ -582,8 +582,8 @@
         "@deck.gl/layers": "^9.1.0",
         "@deck.gl/mesh-layers": "^9.1.0",
         "@loaders.gl/core": "^4.2.0",
-        "@luma.gl/core": "^9.1.3",
-        "@luma.gl/engine": "^9.1.3"
+        "@luma.gl/core": "^9.1.5",
+        "@luma.gl/engine": "^9.1.5"
       }
     },
     "node_modules/@deck.gl/google-maps": {
@@ -2929,15 +2929,6 @@
       "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==",
       "license": "MIT"
     },
-    "node_modules/@types/papaparse": {
-      "version": "5.3.15",
-      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.15.tgz",
-      "integrity": "sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -4165,6 +4156,39 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deck.gl/node_modules/@deck.gl/geo-layers": {
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.5.tgz",
+      "integrity": "sha512-pkqjJW2zF08VH4XH/sHIFwYwAjLeyKa/J5M8sza/VKjaJdcpvktlT/52VqR/4P6IECF4FS6LUNcsBMiiYRoTRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@loaders.gl/3d-tiles": "^4.2.0",
+        "@loaders.gl/gis": "^4.2.0",
+        "@loaders.gl/loader-utils": "^4.2.0",
+        "@loaders.gl/mvt": "^4.2.0",
+        "@loaders.gl/schema": "^4.2.0",
+        "@loaders.gl/terrain": "^4.2.0",
+        "@loaders.gl/tiles": "^4.2.0",
+        "@loaders.gl/wms": "^4.2.0",
+        "@luma.gl/gltf": "^9.1.3",
+        "@luma.gl/shadertools": "^9.1.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@types/geojson": "^7946.0.8",
+        "h3-js": "^4.1.0",
+        "long": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.1.0",
+        "@deck.gl/extensions": "^9.1.0",
+        "@deck.gl/layers": "^9.1.0",
+        "@deck.gl/mesh-layers": "^9.1.0",
+        "@loaders.gl/core": "^4.2.0",
+        "@luma.gl/core": "^9.1.3",
+        "@luma.gl/engine": "^9.1.3"
       }
     },
     "node_modules/deep-is": {
@@ -6087,12 +6111,6 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
-    },
-    "node_modules/papaparse": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz",
-      "integrity": "sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA==",
-      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@arcgis/core": "^4.32.9",
     "@deck.gl/core": "^9.1.5",
+    "@deck.gl/geo-layers": "^9.1.6",
     "@deck.gl/layers": "^9.1.5",
     "@deck.gl/react": "^9.1.5",
     "@deck.gl/widgets": "^9.1.5",
@@ -25,6 +26,7 @@
     "@luma.gl/shadertools": "^9.0.0",
     "deck.gl": "^9.1.5",
     "geojson": "^0.5.0",
+    "h3-js": "^4.1.0",
     "mapbox-gl": "^2.15.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -17,8 +17,9 @@ interface FilterModalProps {
   onClose: () => void;
   data: any[];
   onApplyFilter: (filter: (item: any) => boolean, filterInfo: FilterInfo) => void;
-  activeFilters?: FilterInfo[];
-  onRemoveFilter?: (index: number) => void;
+  activeFilters: FilterInfo[];
+  onRemoveFilter: (index: number) => void;
+  layerType?: 'geojson' | 'point' | 'h3';
 }
 
 interface ColumnInfo {
@@ -32,8 +33,9 @@ export const FilterModal: React.FC<FilterModalProps> = ({
   onClose, 
   data, 
   onApplyFilter,
-  activeFilters = [],
-  onRemoveFilter
+  activeFilters,
+  onRemoveFilter,
+  layerType
 }) => {
   const [columns, setColumns] = useState<ColumnInfo[]>([]);
   const [selectedColumn, setSelectedColumn] = useState<string>('');
@@ -327,7 +329,7 @@ export const FilterModal: React.FC<FilterModalProps> = ({
                 <div key={index} className="flex items-center justify-between bg-gray-50 px-3 py-2 rounded-lg">
                   <span className="text-sm text-gray-600">{formatFilterDescription(filter)}</span>
                   <button
-                    onClick={() => onRemoveFilter?.(index)}
+                    onClick={() => onRemoveFilter(index)}
                     className="text-gray-400 hover:text-gray-500"
                   >
                     <XMarkIcon className="h-4 w-4" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,7 +308,29 @@
     "@luma.gl/shadertools" "^9.1.3"
     "@math.gl/core" "^4.1.0"
 
-"@deck.gl/geo-layers@^9.1.0", "@deck.gl/geo-layers@9.1.5":
+"@deck.gl/geo-layers@^9.1.0", "@deck.gl/geo-layers@^9.1.6":
+  version "9.1.6"
+  resolved "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.6.tgz"
+  integrity sha512-pacef6yKJADZ55oyIPbCHmDWVGSIQpwBiSlAGqiP7m1jWGYsPY6/tHVWHhrbb+Hood7yT4necMum4c6W8S/OGQ==
+  dependencies:
+    "@loaders.gl/3d-tiles" "^4.2.0"
+    "@loaders.gl/gis" "^4.2.0"
+    "@loaders.gl/loader-utils" "^4.2.0"
+    "@loaders.gl/mvt" "^4.2.0"
+    "@loaders.gl/schema" "^4.2.0"
+    "@loaders.gl/terrain" "^4.2.0"
+    "@loaders.gl/tiles" "^4.2.0"
+    "@loaders.gl/wms" "^4.2.0"
+    "@luma.gl/gltf" "^9.1.5"
+    "@luma.gl/shadertools" "^9.1.5"
+    "@math.gl/core" "^4.1.0"
+    "@math.gl/culling" "^4.1.0"
+    "@math.gl/web-mercator" "^4.1.0"
+    "@types/geojson" "^7946.0.8"
+    h3-js "^4.1.0"
+    long "^3.2.0"
+
+"@deck.gl/geo-layers@9.1.5":
   version "9.1.5"
   resolved "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.5.tgz"
   integrity sha512-pkqjJW2zF08VH4XH/sHIFwYwAjLeyKa/J5M8sza/VKjaJdcpvktlT/52VqR/4P6IECF4FS6LUNcsBMiiYRoTRw==
@@ -822,7 +844,7 @@
   resolved "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.1.5.tgz"
   integrity sha512-vxUaL2OAnSxX6h5xgW2fQdlPZjBBXRxQyHfSMYZ2j2iNIKXTuaCGXfbPLuWExLJOPlSLtp34VPualCeAVwr+Ug==
 
-"@luma.gl/core@^9.0.0", "@luma.gl/core@^9.1.0", "@luma.gl/core@^9.1.3":
+"@luma.gl/core@^9.0.0", "@luma.gl/core@^9.1.0", "@luma.gl/core@^9.1.3", "@luma.gl/core@^9.1.5":
   version "9.1.5"
   resolved "https://registry.npmjs.org/@luma.gl/core/-/core-9.1.5.tgz"
   integrity sha512-3nrNWX8pbuKsGCa1g/8dmBbZ9YGguzDpxqS1v4I35OeyZHLKq4GiRbWxxz7tgApMlzS0CBOJOOaBpGqgIpX97w==
@@ -833,7 +855,7 @@
     "@probe.gl/stats" "^4.0.8"
     "@types/offscreencanvas" "^2019.6.4"
 
-"@luma.gl/engine@^9.0.0", "@luma.gl/engine@^9.1.0", "@luma.gl/engine@^9.1.3":
+"@luma.gl/engine@^9.0.0", "@luma.gl/engine@^9.1.0", "@luma.gl/engine@^9.1.3", "@luma.gl/engine@^9.1.5":
   version "9.1.5"
   resolved "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.1.5.tgz"
   integrity sha512-cjhKlz3G8JQACy0kDRI2zQKM02kw2deLuojz0E8MTDUHl4YQG2jpJI6Mr9Vfb3EnIoSg0ACfYMTFCORwUxBL/Q==
@@ -843,7 +865,7 @@
     "@probe.gl/log" "^4.0.8"
     "@probe.gl/stats" "^4.0.8"
 
-"@luma.gl/gltf@^9.1.3":
+"@luma.gl/gltf@^9.1.3", "@luma.gl/gltf@^9.1.5":
   version "9.1.5"
   resolved "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.1.5.tgz"
   integrity sha512-CbtFXnxNBv9BeReLb7YGLAtMysj94G50SDVCRcOmjxH8tObhYqaRRhKC/BfpugXZzzJ1xoqWDrGDy+/A2ENWJQ==
@@ -852,7 +874,7 @@
     "@loaders.gl/textures" "^4.2.0"
     "@math.gl/core" "^4.1.0"
 
-"@luma.gl/shadertools@^9.0.0", "@luma.gl/shadertools@^9.1.0", "@luma.gl/shadertools@^9.1.3":
+"@luma.gl/shadertools@^9.0.0", "@luma.gl/shadertools@^9.1.0", "@luma.gl/shadertools@^9.1.3", "@luma.gl/shadertools@^9.1.5":
   version "9.1.5"
   resolved "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.1.5.tgz"
   integrity sha512-tCQfR2lb7WsIUQ1cPYdmcBFAwY2e7gW95bd29ncn09JIvb8IljQiKxHpVPB5kpLGzfqXbvUQkC5tOBweKW91MA==
@@ -1408,13 +1430,6 @@
   version "1.0.7"
   resolved "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz"
   integrity sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==
-
-"@types/papaparse@^5.3.15":
-  version "5.3.15"
-  resolved "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.15.tgz"
-  integrity sha512-JHe6vF6x/8Z85nCX4yFdDslN11d+1pr12E526X8WAfhadOeaOTx5AuIkvDKIBopfvlzpzkdMx4YyvSKCM9oqtw==
-  dependencies:
-    "@types/node" "*"
 
 "@types/prop-types@*":
   version "15.7.14"
@@ -3343,11 +3358,6 @@ pako@~1.0.2, pako@1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
-papaparse@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.npmjs.org/papaparse/-/papaparse-5.5.2.tgz"
-  integrity sha512-PZXg8UuAc4PcVwLosEEDYjPyfWnTEhOrUfdv+3Bx+NuAb+5NhDmXzg5fHWmdCh1mP5p7JAZfFr3IMQfcntNAdA==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
# Add H3 Hexagon Support and Improve Data Upload UI

## Changes
- Added support for H3 hexagon visualization from CSV files
- Updated CSV upload UI to clearly indicate support for both coordinate-based and H3-based data
- Improved feature property display behavior:
  - Hover to view properties in top-right corner
  - Click to lock/unlock property display
  - Distinct handling for GeoJSON, Points, and H3 hexagons
- Updated README with H3 data format requirements and usage instructions

## Technical Details
- Implemented H3 index detection in CSV files
- Added H3HexagonLayer for rendering hexagons
- Separated layer types into 'geojson', 'point', and 'h3' for better type handling
- Enhanced feature comparison logic for each geometry type
- Added validation for H3 cell addresses

## UI/UX Improvements
- Clear documentation of supported CSV formats in upload UI
- Improved hover/click interaction model for feature properties
- Consistent behavior across all layer types
- Better feedback for H3 data detection and validation

## Documentation
- Added H3 format requirements to README
- Updated usage instructions
- Added examples of valid column names for H3 indices