### PR TITLE
v2.3.1: Fix text filter + autocomplete, add docs and filter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.1] - 2026-06-04
+
+### Fixed
+- **Text filter not working** — `=` text comparison was case-sensitive exact match with no autocomplete, meaning typed values rarely matched actual data. Now uses autocomplete with suggestion dropdown from column's unique values, and text `=` is case-insensitive.
+- **Text filter missing autocomplete** — restored the multi-select suggestion behavior that FilterModal had before the v2.3 redesign. When `=` is selected for a text column, the user can search and pick values from a suggestion dropdown. Multiple picks create OR semantics (exact match).
+- **Config import filter reconstruction** — `applyConfig` now uses `item?.properties?.[col] ?? item?.[col]` fallback pattern (matching `buildFilterFn`), fixing imported filters for H3 and other edge case data shapes. Text `=` comparisons are now case-insensitive on import too.
+- **FilterInfo type** — Added optional `match: 'exact' | 'substring'` field to `multiple` value type, allowing clean separation between autocomplete exact-match and `contains` substring-match without breaking backward compatibility with older saved configs.
+
+### Changed
+- Text `=` operator is now **case-insensitive** for both direct comparison and autocomplete multi-select (was case-sensitive before, causing confusing "filter doesn't work" experience)
+
+### Added
+- **Autocomplete suggestion dropdown** for text `=` filter operator — press ArrowDown/ArrowUp to navigate, Enter to select, Escape to close
+- Selected values shown as **removable chips** before applying the filter
+- **36 new unit tests** for filter logic (`src/utils/__tests__/filter.test.ts`): extractDataItems, buildColumns, buildFilterFn for all operator types, edge cases, backward compatibility
+- Total test count: **57 → 93**
+
 ## [2.3.0] - 2026-04-20
 
 Visual redesign pass — new editorial design system, topbar, rail-based panels. All functional features (DuckDB-WASM, deck.gl, file parsers, filter semantics, config I/O, URL-hash sharing) are preserved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,17 +6,19 @@ MapViewer-GL is a **client-side** geospatial data viewer built with React, deck.
 **Live demo:** https://mapviewer-gl.vercel.app
 **Deployed via:** Vercel (auto-deploy on push to `main`). CI checks in `.github/workflows/ci.yml`.
 
-## UI/UX Source of Truth
+## Documentation Index
 
-The shipped UI is being replaced. When making ANY UI/UX decision on this repo, consult these first:
-- **`UX_SPEC.md`** (repo root) — functional spec: what the app does, user stories, screens. No design decisions.
-- **`docs/design/`** — Claude Design handoff bundle (visual source of truth). Key files:
-  - `docs/design/project/styles.css` — the design system in CSS (OKLCH, typography)
-  - `docs/design/project/MapViewer-GL.html` + `project/*.jsx` — interactive prototype
-  - `docs/design/chats/chat1.md` — designer/user conversation with intent + iteration history
-  - `docs/design/IMPLEMENTATION_PLAN.md` — step-by-step checklist for porting the design onto the real codebase (planned 2026-04-17, not yet executed)
+| Document | Purpose |
+|---|---|
+| `UX_SPEC.md` (repo root) | Functional spec: user stories, screens, edge cases |
+| `docs/PRD.md` | Product requirements: feature inventory, personas, known issues |
+| `docs/ARCHITECTURE.md` | Code architecture: tech stack, state management, data flow, filter design |
+| `docs/TEST_PLAN.md` | Test inventory: coverage gaps, recommended test additions |
+| `docs/design/` | Visual source of truth (OKLCH design system, prototypes) |
+| `docs/design/IMPLEMENTATION_PLAN.md` | v2.3 redesign execution checklist (COMPLETED — design ported to real codebase) |
+| `CHANGELOG.md` | Release history |
 
-Do NOT defer to the current shipped UI when designing new things — it's being replaced per the plan above.
+When making ANY UI/UX decision, consult `UX_SPEC.md` (functional) and `docs/design/` (visual) first. Do NOT defer to the current shipped UI for visual decisions — the v2.3 redesign in `design.css` is the source of truth.
 
 ## Build & Dev Commands
 ```bash
@@ -119,11 +121,24 @@ File upload → parse (CSV/GeoJSON/Shapefile/Parquet)
 | GeoParquet | Yes | Yes | `handleParquetFile` → `extractGeoParquetAsGeoJSON` |
 | Plain Parquet | No | Yes (DuckDB-only) | `handleParquetFile` → no geom detected |
 
-## Known Issues (from CHANGELOG v2.2.0)
+## Known Issues
+
+### Bugs (v2.3.0)
+- **FilterPanel performance:** `buildColumns` iterates ALL data items × ALL columns (O(n×c)) on every render. For 100k features with 10 columns, this blocks the UI for seconds. Should sample data or offload to DuckDB.
+- **Basemap OSM active-state:** `BasemapSelector` compares `mapStyle === style` by object reference. OSM basemap (an object) breaks active-state highlighting after config import (deserialized copy !== static reference).
+- **Symbology columns ignore filters:** `getNumericColumns` in SymbologyPanel doesn't account for active filters — shows all numeric columns even when data is filtered.
+- **GeoJSON color-by-column:** only handles `typeof value === 'number'` — string-numeric properties (e.g. `"100"`) won't be color-mapped, while point/H3 layers DO parse strings.
+- **Size-by-column:** data model supports it but no UI is exposed in SymbologyPanel.
+- **Legend:** only shows the first visible layer's color legend (no size legend, no stacking).
 - H3 column detection only validates the first preview row
 - BigInt values silently converted to Number (precision loss > 2^53)
+
+### Technical debt
+- `papaparse` is still statically imported in MapViewerGL.tsx
 - maplibre-gl and vendor-deckgl chunks exceed 800 KB (expected for these libraries)
-- `papaparse` is still statically imported in MapViewerGL.tsx (used for CSV parsing); `sanitizeTableName` extracted to `tableName.ts` to restore DuckDB lazy-load
+- AddDataModal, CSVPreviewModal, GeoJSONPreviewModal remain on Tailwind styling (phase-2 re-skin)
+- ZERO component-level tests — only utility functions tested (57 tests in `src/utils/__tests__/`)
+- Filter function wrapping for H3 layers is convoluted (double-wrapper that works by accident)
 
 ## Common Tasks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,137 @@
+# MapViewer-GL — Architecture
+
+**Last updated:** 2026-06-04
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | React 18 (function components + hooks) |
+| Map | deck.gl 9.2 + MapLibre GL JS |
+| SQL Engine | DuckDB-WASM (in-browser) |
+| Build | Vite 5 + TypeScript |
+| Styling | Custom CSS (OKLCH design system) + Tailwind (legacy modals) |
+| Testing | Vitest 3 |
+| Package Manager | Yarn 4 (node-modules linker) |
+| Deploy | Vercel (auto-deploy on push to `main`) |
+
+## Design System
+
+- **Colors:** OKLCH space, accent hue 253 (muted lilac)
+- **Fonts:** Instrument Serif (display), Inter (UI, 13px), JetBrains Mono (code/data)
+- **Density:** Compact — 14px padding, 8px gap, 26px row height
+- **Design tokens:** `src/styles/design.css`
+
+## File Structure
+
+```
+src/
+├── App.tsx                    # Root: imports design.css, wraps <MapViewerGL/> in ErrorBoundary
+├── main.tsx                   # Entry: ReactDOM.createRoot + StrictMode
+├── types.ts                   # All shared type definitions (LayerInfo, FilterInfo, etc.)
+├── components/
+│   ├── MapViewerGL.tsx        # Main component — owns ALL state
+│   ├── Topbar.tsx             # Brand + layer count + live coordinates + actions
+│   ├── LayersPanel.tsx        # Left-rail: layer list with swatch/name/meta/actions
+│   ├── SymbologyPanel.tsx     # Left-rail: color, opacity, point size, color-by-column
+│   ├── FilterPanel.tsx        # Left-rail: active filters + add-filter form
+│   ├── Inspector.tsx          # Right-rail: feature attributes (hover/click/pin)
+│   ├── EmptyState.tsx         # Welcome screen with sample data cards
+│   ├── MapControls.tsx        # Zoom in/out/recenter (top-right of map)
+│   ├── BasemapSelector.tsx    # Segmented pill: osm/light/dark (bottom-right)
+│   ├── LegendDisplay.tsx      # Color ramp + breaks card (bottom-left)
+│   ├── SQLEditor.tsx          # Floating SQL workspace overlay
+│   ├── AddDataModal.tsx       # Data import modal (Tailwind — legacy)
+│   ├── CSVPreviewModal.tsx    # CSV column selection (Tailwind — legacy)
+│   ├── GeoJSONPreviewModal.tsx # GeoJSON property selection (Tailwind — legacy)
+│   ├── Toast.tsx              # Toast notification system + useToast hook
+│   ├── ErrorBoundary.tsx      # Catches render crashes, shows recovery UI
+│   └── icons.tsx              # Shared inline SVG icons
+├── styles/
+│   └── design.css             # OKLCH design tokens + component classes
+├── data/
+│   └── samples.ts             # Built-in sample GeoJSON (US Cities, US States)
+├── utils/
+│   ├── duckdb.ts              # DuckDB-WASM init, table CRUD, Parquet/CSV/GeoJSON handling
+│   ├── csv.ts                 # CSV parsing, coordinate/H3 detection, chunk processing
+│   ├── geometry.ts            # Coordinate extraction, bounds, color/size mapping
+│   ├── layers.ts              # Numeric column detection, filtered value extraction
+│   ├── shapefile.ts           # Shapefile (.zip) → GeoJSON via shpjs
+│   ├── tableName.ts           # Sanitize file names → DuckDB-safe table names
+│   └── __tests__/             # Vitest unit tests
+```
+
+## State Management
+
+**MapViewerGL.tsx is the single state owner.** All state lives in `useState` hooks at the top of this component. Child components are pure: they receive props and fire callbacks. There is no Redux, Zustand, or Context.
+
+Key state variables:
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `layers` | `LayerInfo[]` | Map layers with all metadata (symbology, filters, data) |
+| `activeFilters` | `{[layerId]: FilterEntry[]}` | Per-layer filter functions + serializable info |
+| `selectedLayerId` | `number \| null` | Which layer the left-rail panels target |
+| `editTarget` | `'style' \| 'filter'` | Which left-rail panel is showing |
+| `viewState` | `MapViewState` | Current map center + zoom |
+| `mapStyle` | `BasemapStyle` | Current basemap |
+| `selectedFeature` | `Feature \| null` | Feature being hovered or pinned |
+| `isFeatureLocked` | `boolean` | Whether inspector is pinned to a feature |
+| `duckdbOnlyTables` | `DuckDBOnlyTable[]` | Tables without map layers |
+| `registeredTables` | `string[]` | All tables registered in DuckDB |
+| `showSQLEditor` | `boolean` | SQL workspace visibility |
+
+## Data Flow
+
+```
+File upload → parse (csv/geojson/shapefile/parquet)
+  → has geometry? → Add as LayerInfo (map layer) + register in DuckDB
+  → no geometry?  → Add as DuckDBOnlyTable (SQL-only)
+```
+
+deck.gl layers are memoized with `useMemo([layers, activeFilters])`. When layers or filters change, new deck.gl layers are created with filtered data, and deck.gl efficiently diffs them.
+
+## Key Design Decisions
+
+1. **No API keys** — basemaps use free Carto/OSM tiles
+2. **Lazy loading** — DuckDB-WASM (~200KB) and shpjs (~141KB) are dynamic `import()` only
+3. **Code splitting** — deck.gl, React, H3 chunked via Vite `manualChunks`
+4. **Geometry round-trip** — ST_GeomFromGeoJSON / ST_AsGeoJSON (not WKT)
+5. **registeredTablesRef** — `useRef` for DuckDB table tracking to avoid stale closures in async effects
+6. **SQL escaping** — `escapeIdentifier()` for all column names
+7. **URL hash state** — map position persisted in `#lat=...&lng=...&zoom=...` (debounced 300ms)
+8. **ErrorBoundary** — wraps MapViewerGL to prevent white-screen crashes
+9. **DeckGL canvas sizing** — force-sized to 100%×100% via CSS to fill grid cell
+
+## Filter Architecture
+
+```
+FilterPanel                          MapViewerGL                     deck.gl
+───────────                          ──────────                      ───────
+buildColumns(items)                  handleApplyFilter()             useMemo([layers,
+  → ColumnMeta[]                       → wrap for H3                  activeFilters])
+buildFilterFn(column, info)            → setActiveFilters()            → filter data
+  → (item) => boolean                  → new reference                → new deck layers
+handleApply()                                                   
+  → create FilterInfo                                          
+  → call onApplyFilter                                          
+```
+
+The filter chain is:
+1. User fills form in FilterPanel → creates `FilterInfo` + filter function
+2. `handleApplyFilter` wraps H3 filters, stores in `activeFilters` state
+3. State update triggers re-render, `deckLayers` useMemo re-runs
+4. Each layer's data is filtered through `activeFilters[layerId].every(fn)`
+5. Filtered data passed to deck.gl layers, map updates
+
+## DuckDB Integration
+
+Table name: `sanitizeTableName(filename)` — removes extension, replaces special chars with `_`, lowercases, prefixes digit-starting names.
+
+Sync mechanism: `useEffect([layers, isDuckDBReady, duckdbOnlyTables])` keeps DuckDB tables in sync with React state. Uses `registeredTablesRef` for race-condition-safe lookups.
+
+## Confirmation Dialogs
+
+Two destructive actions require confirmation:
+- **Remove layer** — modal with layer name + "This cannot be undone"
+- **Import session config** — modal warning about replacing all current layers

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,136 @@
+# MapViewer-GL — Product Requirements Document
+
+**Version:** 2.3.0
+**Last updated:** 2026-06-04 (audit of v2.3.0 shipped code)
+**Status:** Active development
+
+## Elevator Pitch
+
+A **100% client-side geospatial workspace** where users load data files, style them on an interactive map, filter and inspect features, run spatial SQL queries, and share the resulting view — all without a server or an account.
+
+## Target Personas
+
+| Persona | Need |
+|---|---|
+| Data analyst | Quick visual check of unfamiliar geospatial data |
+| Urban planner / researcher | Overlay, filter, join data sources; share view |
+| Engineer / GIS pro | Sandbox for spatial SQL prototyping |
+| Student / educator | Zero-setup way to learn geospatial concepts |
+| Privacy-conscious user | Visualize data that cannot leave their machine |
+
+## Core Principles
+
+1. **Zero-install, zero-signup, zero-server** — instantly usable
+2. **Data is the hero** — map is the primary surface; controls retractable
+3. **Progressive disclosure** — novice never sees SQL; expert reaches it in one action
+4. **Every layer is queryable** — anything on the map can be SQL-queried; any SQL result can become a map layer
+5. **Nothing destructive without confirmation** — remove/overwrite require explicit confirm
+
+## Feature Inventory
+
+### Data Ingestion
+- [x] GeoJSON upload — becomes map layer + DuckDB table
+- [x] CSV with lat/lng — auto-detect coordinates, becomes point layer
+- [x] CSV with H3 column — auto-detect H3 index, becomes hexagon layer
+- [x] CSV without geometry — registered as SQL-only table
+- [x] Shapefile (.zip) — parsed in-browser, becomes GeoJSON layer
+- [x] GeoParquet — auto-detect geometry column, becomes map layer
+- [x] Plain Parquet — registered as SQL-only table
+- [x] Session config (.json) — import/export full session
+- [x] Drag-and-drop anywhere on the map canvas
+- [x] Sample datasets (US Cities, US States) — one-click load
+- [x] Column/property selection before loading
+- [x] Coordinate column auto-detection (lat/lng/latitude/longitude/x/y)
+- [x] H3 column auto-detection (hex_id/h3_index/h3/hexagon)
+- [x] Progress indicator for large files
+
+### Layer Management
+- [x] Layer list with color swatch + name + meta (source type, count)
+- [x] Visibility toggle per layer
+- [x] Rename layer (double-click or rename button)
+- [x] Reorder layers (drag handle)
+- [x] Remove layer with confirmation modal
+- [x] Map layers vs SQL-only tables visually distinguished
+- [x] Filter count badge on layer rows
+
+### Symbology
+- [x] Base color picker
+- [x] Opacity slider (0–100%)
+- [x] Point size slider (point layers)
+- [x] Color-by-column with 8 sequential palettes (ColorBrewer-inspired: Reds, Blues, Greens, Greys, YlGnBu, YlOrRd, PuBuGn, RdPu)
+- [x] Number of classes control (3–10)
+- [x] Live updates (no separate "apply" step)
+- [ ] Size-by-column (UI not yet implemented; data model supports it)
+
+### Filtering
+- [x] Numeric range filter (min ≤ v ≤ max) with column min/max defaults
+- [x] Numeric comparison (=, <, <=, >, >=)
+- [x] Text exact comparison (case-sensitive =)
+- [x] Text contains (case-insensitive substring, comma-separated OR)
+- [x] Stack multiple filters per layer (AND semantics)
+- [x] Filter count badge visible in layer list
+- [x] Remove individual filter
+- [x] Filters preserved in exported configurations
+
+### Feature Inspection
+- [x] Hover to peek feature attributes
+- [x] Click to pin inspection panel
+- [x] Primary label detection (name/NAME/title/id)
+- [x] Coordinate display for point features
+- [x] Key-value attribute table
+
+### SQL Workspace
+- [x] DuckDB-WASM with spatial extension
+- [x] All layers available as SQL tables
+- [x] Tables-in-scope sidebar with click-to-insert
+- [x] Query templates (preview, count, spatial join, buffer+intersect)
+- [x] Cmd/Ctrl+Enter to run query
+- [x] Results table with row count + execution time
+- [x] Geometry column detection → "Add as map layer"
+- [x] Export results as CSV
+- [x] Error messages inline
+
+### Map
+- [x] Pan, zoom, scroll-wheel zoom, pinch-zoom
+- [x] 3 basemaps: Carto Light, Carto Dark, OpenStreetMap
+- [x] Zoom in/out/recenter controls
+- [x] Auto-zoom to new layer extent
+- [x] Color legend (auto-displays for classified layers)
+- [ ] Size legend (not yet implemented)
+
+### Sharing & Persistence
+- [x] Full session export as JSON (layers, styling, filters, view state, basemap)
+- [x] Session import with overwrite confirmation
+- [x] URL hash sharing (lat/lng/zoom)
+- [ ] URL hash does not encode layers/data (by design — privacy)
+
+### Error Handling
+- [x] ErrorBoundary (catches render crashes, shows recovery UI)
+- [x] Toast notifications for errors, warnings, info
+- [x] Malformed file → specific error message
+- [x] Unsupported file format → clear error
+- [x] SQL syntax errors → inline in editor
+
+### Cross-cutting
+- [x] all browser processing (no server)
+- [x] No API keys required
+- [ ] Responsive/mobile layout (not in v2.3 scope)
+
+## Out of Scope (by design)
+- User accounts / cloud storage
+- Real-time collaboration
+- Drawing/editing geometry
+- Time-series animation
+- 3D/extrusion
+- Map export as PNG/PDF
+- Geocoding
+- Commercial basemaps (Mapbox, Google)
+
+## Known Issues (v2.3.0)
+1. FilterPanel column computation is O(n×c) and blocks UI for large datasets
+2. No component-level tests (only utility functions tested)
+3. Size-by-column UI not exposed in SymbologyPanel
+4. Basemap active-state comparison breaks for OSM after config import
+5. GeoJSON color-by-column only handles `typeof number`, not string-numeric
+6. Only first visible layer's legend is shown (no stacking)
+7. AddDataModal, CSVPreviewModal, GeoJSONPreviewModal still on Tailwind (phase-2 re-skin pending)

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,91 @@
+# MapViewer-GL — Test Plan
+
+**Last updated:** 2026-06-04 (audit of v2.3.0 shipped code)
+
+## Current State: 57 Tests, All Passing
+
+| Module | Tests | Covers |
+|---|---|---|
+| `csv.test.ts` | 15 | `detectCoordinateColumns`, `detectH3Column`, `processChunk` |
+| `duckdb.test.ts` | 20 | `sanitizeTableName`, `escapeIdentifier`, `inferColumnType`, `formatValue` |
+| `geometry.test.ts` | 16 | `extractCoordinates`, `calculateBounds`, `hexToRGB`, `getColorForValue`, `getSizeForValue` |
+| `layers.test.ts` | 6 | `getNumericColumns`, `getNumericValuesForColumn` (including with active filters) |
+
+## Coverage Gaps
+
+### Critical — No component tests exist
+- `FilterPanel` — `buildColumns`, `buildFilterFn`, form state management, edge cases
+- `SymbologyPanel` — column detection, palette selection, color/opacity/size propagation
+- `LayersPanel` — selection, visibility toggle, rename, drag-reorder
+- `MapViewerGL` — filter application in deckLayers useMemo, state synchronization
+- `SQLEditor` — query execution, table injection, add-as-layer
+- `Inspector` — feature display, pin/unpin, formatCoordinate
+- `BasemapSelector` — selection state, object comparison
+- `LegendDisplay` — legend rendering with breaks
+- `MapControls` — zoom/recenter callbacks
+- `Toast` — add/remove/auto-dismiss
+
+### Missing Utility Tests
+- `tableName.ts` — no dedicated test file (tested indirectly via duckdb.test.ts)
+- CSV column selection logic in `MapViewerGL.tsx` — `toggleColumnSelection`, `proceedWithSelectedColumns`
+- GeoJSON property selection — `toggleGeoJSONPropertySelection`, `proceedWithSelectedGeoJSONProperties`
+- Configuration export/import — `exportConfiguration`, `applyConfig` (filter reconstruction)
+- URL hash parsing — `parseHashViewState`
+- Feature equality — `areFeaturesEqual`
+
+### Missing Integration Tests
+- Full filter flow: add filter → verify deckLayers useMemo output has fewer items
+- Full symbology flow: enable color-by-column → verify breaks computed correctly
+- Full data flow: upload CSV → preview → select columns → layer created
+- Config round-trip: add layer with filters → export → import → verify filters preserved
+- SQL: run query with geometry → add as layer → verify layer in list
+
+## Recommended Test Additions
+
+### Priority 1 — Filter logic (extract and test)
+```
+src/utils/__tests__/filter.test.ts
+  - buildColumns: numeric/text detection, empty data, mixed types
+  - buildFilterFn: numeric range, numeric comparison, text exact, text contains
+  - extractDataItems: geojson, point, h3 data normalization
+```
+
+### Priority 2 — Filter integration (component test)
+```
+src/components/__tests__/FilterPanel.test.tsx
+  - Renders with empty filter state
+  - Adds numeric range filter
+  - Adds text contains filter
+  - Shows correct filter count in active list
+  - Removes a filter
+```
+
+### Priority 3 — Symbology
+```
+src/utils/__tests__/symbology.test.ts
+  - getNumericColumns with edge cases
+  - Color mapping break computation
+  - Size mapping break computation
+```
+
+### Priority 4 — Config round-trip
+```
+src/__tests__/config.test.ts
+  - Export: all layer types with filters → valid JSON
+  - Import: config JSON → valid LayerInfo array
+  - Import: config with filters → activeFilters correctly reconstructed
+  - Import: config version check
+```
+
+## Test Infrastructure
+
+- **Runner:** Vitest 3.x
+- **Environment:** `node` (no jsdom — cannot render React components in tests)
+- **To add component tests:** need to add `@testing-library/react` + `jsdom` or `happy-dom`
+
+## Test Commands
+```bash
+yarn test          # Run all tests
+yarn test --watch  # Watch mode
+yarn build         # Also runs tsc type check
+```

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,29 +1,26 @@
 /**
- * Left-rail filter panel. Replaces the old modal-style FilterModal but preserves
- * the same filter capabilities:
- *   - numeric `range` — bounded inclusive range (min ≤ v ≤ max)
- *   - numeric/text `=`, `<`, `<=`, `>`, `>=` — exact comparison (serialized as
- *     `type: 'comparison'`)
- *   - text `contains` — case-insensitive substring match with comma-separated
- *     OR semantics (serialized as `type: 'multiple'`)
+ * Left-rail filter panel. Replaces the old modal-style FilterModal.
  *
- * The `=` operator for text is *exact* and case-sensitive, matching the old
- * FilterModal's direct-text-input path. Use `contains` for the old
- * multi-select/partial-match behavior. This split is load-bearing so that
- * imported saved sessions keep their semantics.
+ * Filter capabilities:
+ *   - numeric `range` — bounded inclusive range (min ≤ v ≤ max)
+ *   - numeric `=`, `<`, `<=`, `>`, `>=` — exact comparison
+ *   - text `=` — autocomplete multi-select from column's unique values.
+ *     Click suggestions to pick exact values (OR semantics, case-insensitive).
+ *   - text `<`, `<=`, `>`, `>=` — exact string comparison
+ *   - text `contains` — case-insensitive substring match with comma-separated
+ *     OR semantics
  */
 
-import React, { useState, useMemo, useEffect } from 'react';
-import type { LayerInfo, FilterInfo } from '../types';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
+import type { LayerInfo, FilterInfo, ComparisonOperator } from '../types';
 import { CloseIcon } from './icons';
 
-type ComparisonOperator = '=' | '<=' | '<' | '>=' | '>';
 /** Operators available in the rail UI. `range` (numeric) and `contains` (text)
  *  are UI-only variants that serialize to `type: 'range'` and `type: 'multiple'`
  *  respectively. The five comparison operators serialize to `type: 'comparison'`. */
-type Operator = ComparisonOperator | 'range' | 'contains';
+export type Operator = ComparisonOperator | 'range' | 'contains';
 
-type ColumnMeta = {
+export type ColumnMeta = {
   name: string;
   type: 'numeric' | 'text';
   uniqueValues?: string[];
@@ -31,7 +28,7 @@ type ColumnMeta = {
   max?: number;
 };
 
-interface ActiveFilterEntry {
+export interface ActiveFilterEntry {
   fn: (item: any) => boolean;
   info: FilterInfo;
 }
@@ -43,13 +40,14 @@ interface FilterPanelProps {
   onRemoveFilter: (layerId: number, index: number) => void;
 }
 
-const extractDataItems = (layer: LayerInfo): any[] => {
+export const extractDataItems = (layer: LayerInfo): any[] => {
   if (layer.type === 'geojson') return (layer.data?.features || []) as any[];
   if (layer.type === 'h3') return (layer.data || []).map((d: any) => ({ properties: d.properties }));
   return (layer.data || []) as any[];
 };
 
-const buildColumns = (items: any[]): ColumnMeta[] => {
+/** Detect column types, min/max for numeric, unique values for text.  */
+export const buildColumns = (items: any[]): ColumnMeta[] => {
   if (items.length === 0) return [];
   const first = items[0]?.properties ?? items[0];
   if (!first || typeof first !== 'object') return [];
@@ -79,24 +77,35 @@ const buildColumns = (items: any[]): ColumnMeta[] => {
   });
 };
 
-const buildFilterFn = (column: ColumnMeta, info: FilterInfo): (item: any) => boolean => {
+/**
+ * Build a filter function from a ColumnMeta and a serialised FilterInfo.
+ *
+ * When `info.value.type === 'multiple'` and `match === 'exact'`, the function
+ * performs a case-insensitive exact match against each value (OR semantics).
+ * This is the autocomplete / multi-select path for text `=`.
+ *
+ * When `match` is absent or `'substring'`, it does case-insensitive substring
+ * matching — the legacy `contains` path.
+ */
+export const buildFilterFn = (column: ColumnMeta, info: FilterInfo): (item: any) => boolean => {
   return (item: any) => {
     const raw = item?.properties?.[column.name] ?? item?.[column.name];
-    // Discriminate on the inner `value.type` — the outer `info.type`
-    // ('numeric' | 'text') doesn't let TS narrow the inner union by itself.
+
     if (info.value.type === 'range') {
       const n = typeof raw === 'number' ? raw : parseFloat(String(raw));
       if (isNaN(n)) return false;
       return n >= info.value.min && n <= info.value.max;
     }
+
     if (info.value.type === 'multiple') {
-      // `contains` — case-insensitive substring match with OR-of-values.
+      if (info.value.match === 'exact') {
+        const s = String(raw ?? '').toLowerCase();
+        return info.value.values.some((v) => s === v.toLowerCase());
+      }
       const lower = String(raw ?? '').toLowerCase();
       return info.value.values.some((v) => lower.includes(v.toLowerCase()));
     }
-    // value.type === 'comparison'. Numeric filters compare as numbers;
-    // text filters preserve case (matching the old FilterModal's direct-text
-    // `=` path).
+
     if (info.type === 'numeric') {
       const n = typeof raw === 'number' ? raw : parseFloat(String(raw));
       if (isNaN(n)) return false;
@@ -109,10 +118,11 @@ const buildFilterFn = (column: ColumnMeta, info: FilterInfo): (item: any) => boo
         case '>=': return n >= v;
       }
     }
+
     const raw_s = String(raw ?? '');
     const v = String(info.value.value);
     switch (info.value.operator) {
-      case '=': return raw_s === v;
+      case '=': return raw_s.toLowerCase() === v.toLowerCase();
       case '<': return raw_s < v;
       case '<=': return raw_s <= v;
       case '>': return raw_s > v;
@@ -136,6 +146,13 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   const [rangeMin, setRangeMin] = useState<string>('');
   const [rangeMax, setRangeMax] = useState<string>('');
 
+  // Autocomplete state for text `=` — multi-select chips + search
+  const [pickedValues, setPickedValues] = useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const suggestionRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (columns.length > 0 && !columns.some((c) => c.name === colName)) {
       setColName(columns[0].name);
@@ -144,29 +161,64 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
 
   const currentCol = columns.find((c) => c.name === colName);
 
-  // Reset the draft whenever the selected layer OR the selected column changes.
-  // Keying off layer.id is load-bearing — two layers can have the same column
-  // name (e.g. `name`, `population`), and without this a stale value/range from
-  // the previous layer would silently apply to the new one.
+  // Reset draft when layer or column changes
   useEffect(() => {
     setValue('');
+    setPickedValues([]);
+    setShowSuggestions(false);
     if (currentCol?.type === 'numeric') {
       setRangeMin(currentCol.min !== undefined ? String(currentCol.min) : '');
       setRangeMax(currentCol.max !== undefined ? String(currentCol.max) : '');
-      // `contains` is text-only — reset to `=` so the dropdown stays valid.
       if (op === 'contains') setOp('=');
     } else {
       setRangeMin('');
       setRangeMax('');
-      // `range` is numeric-only — reset to `=` so the dropdown stays valid.
       if (op === 'range') setOp('=');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layer.id, colName]);
 
+  // Filtered suggestions for autocomplete
+  const filteredSuggestions = useMemo(() => {
+    if (currentCol?.type !== 'text' || op !== '=' || !currentCol.uniqueValues) return [];
+    const q = value.toLowerCase();
+    // Exclude already-picked values; show up to 50
+    return currentCol.uniqueValues
+      .filter((v) => !pickedValues.includes(v) && v.toLowerCase().includes(q))
+      .slice(0, 50);
+  }, [currentCol, op, value, pickedValues]);
+
+  // Close suggestions on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        showSuggestions &&
+        suggestionRef.current &&
+        searchRef.current &&
+        !suggestionRef.current.contains(e.target as Node) &&
+        !searchRef.current.contains(e.target as Node)
+      ) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showSuggestions]);
+
+  const togglePick = (val: string) => {
+    setPickedValues((prev) =>
+      prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]
+    );
+  };
+
+  const removePick = (val: string) => {
+    setPickedValues((prev) => prev.filter((v) => v !== val));
+  };
+
   const handleApply = () => {
     if (!currentCol) return;
     let info: FilterInfo;
+
     if (currentCol.type === 'numeric') {
       if (op === 'range') {
         const min = parseFloat(rangeMin);
@@ -174,7 +226,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         if (isNaN(min) || isNaN(max)) return;
         info = { column: currentCol.name, type: 'numeric', value: { type: 'range', min, max } };
       } else if (op === 'contains') {
-        return; // `contains` is text-only
+        return;
       } else {
         const n = parseFloat(value);
         if (isNaN(n)) return;
@@ -182,27 +234,44 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
       }
     } else {
       if (op === 'range') return;
-      const trimmed = value.trim();
-      if (trimmed.length === 0) return;
-      if (op === 'contains') {
-        // Split on comma for OR semantics; trim empties. Single value → [value].
+
+      if (op === '=' && pickedValues.length > 0) {
+        info = { column: currentCol.name, type: 'text', value: { type: 'multiple', values: pickedValues, match: 'exact' } };
+      } else if (op === 'contains') {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) return;
         const values = trimmed.split(',').map((v) => v.trim()).filter(Boolean);
         if (values.length === 0) return;
         info = { column: currentCol.name, type: 'text', value: { type: 'multiple', values } };
       } else {
-        // `=`, `<`, `<=`, `>`, `>=` all use exact comparison — preserves parity
-        // with the old FilterModal where direct-text `=` was case-sensitive ===.
+        const trimmed = value.trim();
+        if (trimmed.length === 0) return;
         info = { column: currentCol.name, type: 'text', value: { type: 'comparison', operator: op, value: trimmed } };
       }
     }
 
     onApplyFilter(layer.id, buildFilterFn(currentCol, info), info);
     setValue('');
+    setPickedValues([]);
+    setShowSuggestions(false);
   };
 
   const opOptions: Operator[] = currentCol?.type === 'numeric'
     ? ['=', '<', '<=', '>', '>=', 'range']
     : ['=', '<', '<=', '>', '>=', 'contains'];
+
+  // Render label for an active filter
+  const filterLabel = (info: FilterInfo): string => {
+    if (info.value.type === 'range') return 'range';
+    if (info.value.type === 'multiple') return info.value.match === 'exact' ? 'is' : 'contains';
+    return info.value.operator;
+  };
+
+  const filterValue = (info: FilterInfo): string => {
+    if (info.value.type === 'range') return `${info.value.min}…${info.value.max}`;
+    if (info.value.type === 'multiple') return info.value.values.join(', ');
+    return String(info.value.value);
+  };
 
   return (
     <div className="panel-section">
@@ -219,20 +288,8 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         {activeFilters.map((f, i) => (
           <div key={i} className="filter-row">
             <code>{f.info.column}</code>
-            <span className="muted">
-              {f.info.value.type === 'range'
-                ? 'range'
-                : f.info.value.type === 'multiple'
-                ? 'contains'
-                : f.info.value.operator}
-            </span>
-            <code>
-              {f.info.value.type === 'range'
-                ? `${f.info.value.min}…${f.info.value.max}`
-                : f.info.value.type === 'multiple'
-                ? f.info.value.values.join(', ')
-                : String(f.info.value.value)}
-            </code>
+            <span className="muted">{filterLabel(f.info)}</span>
+            <code>{filterValue(f.info)}</code>
             <span className="space" />
             <button className="icon-btn" onClick={() => onRemoveFilter(layer.id, i)} aria-label="Remove filter">
               <CloseIcon size={11} />
@@ -281,6 +338,26 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               ))}
             </select>
           </div>
+
+          {/* Picked chips for text autocomplete */}
+          {currentCol?.type === 'text' && op === '=' && pickedValues.length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+              {pickedValues.map((v) => (
+                <span key={v} className="chip" style={{ fontSize: 11 }}>
+                  {v}
+                  <button
+                    className="icon-btn"
+                    style={{ marginLeft: 4, width: 14, height: 14 }}
+                    onClick={() => removePick(v)}
+                    aria-label={`Remove ${v}`}
+                  >
+                    <CloseIcon size={8} />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+
           {op === 'range' && currentCol?.type === 'numeric' ? (
             <div className="row" style={{ gap: 6 }}>
               <input
@@ -303,6 +380,140 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               />
               <button className="btn sm accent" onClick={handleApply}>Add</button>
             </div>
+          ) : currentCol?.type === 'text' && op === '=' ? (
+            /* Autocomplete multi-select for text = */
+            <div style={{ position: 'relative' }}>
+              <div className="row" style={{ gap: 6 }}>
+                <input
+                  ref={searchRef}
+                  className="input"
+                  style={{ flex: 1 }}
+                  type="text"
+                  placeholder="Type to search suggestions…"
+                  value={value}
+                  onChange={(e) => {
+                    setValue(e.target.value);
+                    setShowSuggestions(true);
+                    setHighlightIndex(-1);
+                  }}
+                  onFocus={() => {
+                    if (filteredSuggestions.length > 0) setShowSuggestions(true);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      // If a suggestion is highlighted, pick it
+                      if (showSuggestions && highlightIndex >= 0 && highlightIndex < filteredSuggestions.length) {
+                        togglePick(filteredSuggestions[highlightIndex]);
+                        setValue('');
+                        setShowSuggestions(false);
+                        setHighlightIndex(-1);
+                      } else if (pickedValues.length > 0) {
+                        handleApply();
+                      }
+                      e.preventDefault();
+                    }
+                    if (e.key === 'ArrowDown') {
+                      e.preventDefault();
+                      setShowSuggestions(true);
+                      setHighlightIndex((prev) =>
+                        prev < filteredSuggestions.length - 1 ? prev + 1 : 0
+                      );
+                    }
+                    if (e.key === 'ArrowUp') {
+                      e.preventDefault();
+                      setHighlightIndex((prev) =>
+                        prev > 0 ? prev - 1 : filteredSuggestions.length - 1
+                      );
+                    }
+                    if (e.key === 'Escape') {
+                      setShowSuggestions(false);
+                      setHighlightIndex(-1);
+                    }
+                  }}
+                  aria-label="Search filter values"
+                />
+                <button className="btn sm accent" onClick={handleApply} disabled={pickedValues.length === 0}>
+                  Add
+                </button>
+              </div>
+              {showSuggestions && filteredSuggestions.length > 0 && (
+                <div
+                  ref={suggestionRef}
+                  className="suggestions-dropdown"
+                  style={{
+                    position: 'absolute',
+                    zIndex: 10,
+                    top: '100%',
+                    left: 0,
+                    right: 58,
+                    marginTop: 2,
+                    maxHeight: 180,
+                    overflowY: 'auto',
+                    background: 'var(--surface)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 8,
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                  }}
+                >
+                  {filteredSuggestions.map((s, i) => {
+                    const picked = pickedValues.includes(s);
+                    return (
+                      <div
+                        key={s}
+                        className={`suggestion-item ${i === highlightIndex ? 'highlighted' : ''}`}
+                        style={{
+                          padding: '5px 10px',
+                          fontSize: 12,
+                          cursor: 'pointer',
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 6,
+                          background: i === highlightIndex ? 'var(--bg-sunken)' : picked ? 'var(--accent-soft)' : undefined,
+                        }}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          togglePick(s);
+                          setValue('');
+                          searchRef.current?.focus();
+                        }}
+                        onMouseEnter={() => setHighlightIndex(i)}
+                      >
+                        <span style={{ width: 14, fontSize: 10, flexShrink: 0 }}>
+                          {picked ? '✓' : ''}
+                        </span>
+                        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {s}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+              {showSuggestions && filteredSuggestions.length === 0 && value.length > 0 && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    zIndex: 10,
+                    top: '100%',
+                    left: 0,
+                    right: 58,
+                    marginTop: 2,
+                    padding: '6px 10px',
+                    fontSize: 11,
+                    color: 'var(--ink-3)',
+                    background: 'var(--surface)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 8,
+                  }}
+                >
+                  No matching values found
+                </div>
+              )}
+              <div className="muted" style={{ fontSize: 11, marginTop: 4 }}>
+                Search and click to pick values.{' '}
+                {pickedValues.length > 0 ? `${pickedValues.length} selected — press Add to apply.` : 'Select at least one to enable the filter.'}
+              </div>
+            </div>
           ) : (
             <div className="row" style={{ gap: 6 }}>
               <input
@@ -321,6 +532,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               <button className="btn sm accent" onClick={handleApply}>Add</button>
             </div>
           )}
+
           {currentCol?.type === 'text' && op === 'contains' && (
             <div className="muted" style={{ fontSize: 11 }}>
               Case-insensitive substring match. Use commas to OR multiple terms.
@@ -328,7 +540,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           )}
           {currentCol?.type === 'text' && op === '=' && (
             <div className="muted" style={{ fontSize: 11 }}>
-              Exact, case-sensitive match. Use <code>contains</code> for partial or multi-term matches.
+              Search suggestions from the data above. Pick one or more values, then press Add.
             </div>
           )}
         </div>

--- a/src/components/MapViewerGL.tsx
+++ b/src/components/MapViewerGL.tsx
@@ -713,37 +713,39 @@ const MapViewerGL: React.FC = () => {
         if (layerConfig.filters && layerConfig.filters.length > 0) {
           newFilters[importedIds[index]] = layerConfig.filters.map((filterInfo) => ({
             fn: (item: any) => {
-              const value = item.properties?.[filterInfo.column];
+              const raw = item?.properties?.[filterInfo.column] ?? item?.[filterInfo.column];
               if (filterInfo.type === 'numeric') {
-                const numValue = parseFloat(value);
+                const n = typeof raw === 'number' ? raw : parseFloat(String(raw));
+                if (isNaN(n)) return false;
                 if (filterInfo.value.type === 'range') {
-                  return numValue >= filterInfo.value.min && numValue <= filterInfo.value.max;
+                  return n >= filterInfo.value.min && n <= filterInfo.value.max;
                 } else if (filterInfo.value.type === 'comparison') {
-                  const compValue = parseFloat(String(filterInfo.value.value));
+                  const compValue = Number(filterInfo.value.value);
                   switch (filterInfo.value.operator) {
-                    case '<': return numValue < compValue;
-                    case '<=': return numValue <= compValue;
-                    case '>': return numValue > compValue;
-                    case '>=': return numValue >= compValue;
-                    case '=': return numValue === compValue;
+                    case '<': return n < compValue;
+                    case '<=': return n <= compValue;
+                    case '>': return n > compValue;
+                    case '>=': return n >= compValue;
+                    case '=': return n === compValue;
                     default: return true;
                   }
                 }
               } else if (filterInfo.type === 'text') {
-                const raw = String(value ?? '');
                 if (filterInfo.value.type === 'multiple') {
-                  // `contains` — case-insensitive substring, OR over values.
-                  const lower = raw.toLowerCase();
+                  if (filterInfo.value.match === 'exact') {
+                    const s = String(raw ?? '').toLowerCase();
+                    return filterInfo.value.values.some((v) => s === v.toLowerCase());
+                  }
+                  const lower = String(raw ?? '').toLowerCase();
                   return filterInfo.value.values.some((v) => lower.includes(v.toLowerCase()));
                 } else if (filterInfo.value.type === 'comparison') {
-                  // Comparison preserves case — mirrors the old FilterModal.
                   const compValue = String(filterInfo.value.value);
                   switch (filterInfo.value.operator) {
-                    case '=': return raw === compValue;
-                    case '<': return raw < compValue;
-                    case '<=': return raw <= compValue;
-                    case '>': return raw > compValue;
-                    case '>=': return raw >= compValue;
+                    case '=': return String(raw ?? '').toLowerCase() === compValue.toLowerCase();
+                    case '<': return String(raw ?? '') < compValue;
+                    case '<=': return String(raw ?? '') <= compValue;
+                    case '>': return String(raw ?? '') > compValue;
+                    case '>=': return String(raw ?? '') >= compValue;
                     default: return true;
                   }
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface FilterInfo {
   value:
     | { type: 'range'; min: number; max: number }
     | { type: 'comparison'; operator: ComparisonOperator; value: number | string }
-    | { type: 'multiple'; values: string[] };
+    | { type: 'multiple'; values: string[]; match?: 'exact' | 'substring' };
 }
 
 /** Available sequential color scale names (ColorBrewer-inspired). */

--- a/src/utils/__tests__/filter.test.ts
+++ b/src/utils/__tests__/filter.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from 'vitest';
+import type { FilterInfo, LayerInfo } from '../../types';
+import { extractDataItems, buildColumns, buildFilterFn } from '../../components/FilterPanel';
+import type { ColumnMeta } from '../../components/FilterPanel';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const makeGeoJSONLayer = (features: any[]): LayerInfo => ({
+  id: 1,
+  name: 'test',
+  type: 'geojson',
+  data: { type: 'FeatureCollection', features },
+  visible: true,
+  color: '#ff0000',
+  opacity: 0.7,
+});
+
+const makePointLayer = (data: any[]): LayerInfo => ({
+  id: 2,
+  name: 'points',
+  type: 'point',
+  data,
+  visible: true,
+  color: '#ff0000',
+  opacity: 0.7,
+  columns: { lat: 'lat', lng: 'lng' },
+  pointSize: 5,
+});
+
+const makeH3Layer = (data: any[]): LayerInfo => ({
+  id: 3,
+  name: 'hexes',
+  type: 'h3',
+  data,
+  visible: true,
+  color: '#ff0000',
+  opacity: 0.7,
+});
+
+// ── extractDataItems ─────────────────────────────────────────────────
+
+describe('extractDataItems', () => {
+  it('returns features for geojson layers', () => {
+    const layer = makeGeoJSONLayer([
+      { type: 'Feature', geometry: null, properties: { a: 1 } },
+    ]);
+    expect(extractDataItems(layer)).toHaveLength(1);
+    expect(extractDataItems(layer)[0].properties.a).toBe(1);
+  });
+
+  it('returns empty array for geojson with no features', () => {
+    const layer = makeGeoJSONLayer([]);
+    expect(extractDataItems(layer)).toEqual([]);
+  });
+
+  it('returns data as-is for point layers', () => {
+    const layer = makePointLayer([
+      { position: [0, 0], properties: { name: 'A' } },
+    ]);
+    expect(extractDataItems(layer)[0].position).toEqual([0, 0]);
+    expect(extractDataItems(layer)[0].properties.name).toBe('A');
+  });
+
+  it('wraps H3 data with properties sub-key', () => {
+    const layer = makeH3Layer([
+      { hex: '811fbffffffffff', properties: { pop: 1000 } },
+    ]);
+    const items = extractDataItems(layer);
+    expect(items[0].properties).toBeDefined();
+    expect(items[0].properties.pop).toBe(1000);
+  });
+});
+
+// ── buildColumns ─────────────────────────────────────────────────────
+
+describe('buildColumns', () => {
+  it('returns empty for empty items', () => {
+    expect(buildColumns([])).toEqual([]);
+  });
+
+  it('detects numeric column', () => {
+    const items = [{ properties: { pop: 100 } }, { properties: { pop: 200 } }];
+    const cols = buildColumns(items);
+    expect(cols.find((c) => c.name === 'pop')?.type).toBe('numeric');
+  });
+
+  it('detects text column', () => {
+    const items = [
+      { properties: { name: 'Chicago' } },
+      { properties: { name: 'New York' } },
+    ];
+    const cols = buildColumns(items);
+    expect(cols.find((c) => c.name === 'name')?.type).toBe('text');
+  });
+
+  it('includes unique values for text columns', () => {
+    const items = [
+      { properties: { state: 'CA' } },
+      { properties: { state: 'NY' } },
+      { properties: { state: 'CA' } },
+    ];
+    const col = buildColumns(items).find((c) => c.name === 'state')!;
+    expect(col.type).toBe('text');
+    expect(col.uniqueValues).toEqual(['CA', 'NY']);
+  });
+
+  it('stores min and max for numeric columns', () => {
+    const items = [
+      { properties: { val: 10 } },
+      { properties: { val: 20 } },
+      { properties: { val: 5 } },
+    ];
+    const col = buildColumns(items).find((c) => c.name === 'val')!;
+    expect(col.type).toBe('numeric');
+    expect(col.min).toBe(5);
+    expect(col.max).toBe(20);
+  });
+
+  it('handles null/empty values without error', () => {
+    const items = [
+      { properties: { name: 'A', pop: null } },
+      { properties: { name: 'B', pop: 200 } },
+    ];
+    const cols = buildColumns(items);
+    const popCol = cols.find((c) => c.name === 'pop')!;
+    expect(popCol.min).toBe(200);
+    expect(popCol.max).toBe(200);
+  });
+
+  it('handles items without properties (raw objects)', () => {
+    const items = [{ name: 'A' }, { name: 'B' }];
+    const cols = buildColumns(items);
+    expect(cols.find((c) => c.name === 'name')?.type).toBe('text');
+  });
+
+  it('handles string-numeric values as numeric if ≥50%', () => {
+    const items = [
+      { properties: { val: '10' } },
+      { properties: { val: '20' } },
+      { properties: { val: 'x' } },
+      { properties: { val: '30' } },
+    ];
+    const col = buildColumns(items).find((c) => c.name === 'val')!;
+    // 3/4 are numeric → isNumeric
+    expect(col.type).toBe('numeric');
+  });
+
+  it('filters out "position" key', () => {
+    const items = [
+      { position: [0, 0], properties: { name: 'A' } },
+    ];
+    const cols = buildColumns(items);
+    expect(cols.find((c) => c.name === 'position')).toBeUndefined();
+  });
+});
+
+// ── buildFilterFn ────────────────────────────────────────────────────
+
+describe('buildFilterFn — numeric range', () => {
+  const col: ColumnMeta = { name: 'pop', type: 'numeric' };
+  const info: FilterInfo = {
+    column: 'pop',
+    type: 'numeric',
+    value: { type: 'range', min: 100, max: 500 },
+  };
+  const fn = buildFilterFn(col, info);
+
+  it('includes value within range', () => {
+    expect(fn({ properties: { pop: 300 } })).toBe(true);
+    expect(fn({ properties: { pop: 100 } })).toBe(true);
+    expect(fn({ properties: { pop: 500 } })).toBe(true);
+  });
+
+  it('excludes value outside range', () => {
+    expect(fn({ properties: { pop: 50 } })).toBe(false);
+    expect(fn({ properties: { pop: 600 } })).toBe(false);
+  });
+
+  it('excludes null/undefined', () => {
+    expect(fn({ properties: { pop: null } })).toBe(false);
+    expect(fn({ properties: {} })).toBe(false);
+  });
+
+  it('handles string values', () => {
+    expect(fn({ properties: { pop: '300' } })).toBe(true);
+  });
+
+  it('uses ?? fallback for items without .properties', () => {
+    expect(fn({ pop: 300 })).toBe(true);
+  });
+});
+
+describe('buildFilterFn — numeric comparison', () => {
+  const col: ColumnMeta = { name: 'val', type: 'numeric' };
+
+  it('= works', () => {
+    const fn = buildFilterFn(col, { column: 'val', type: 'numeric', value: { type: 'comparison', operator: '=', value: 42 } });
+    expect(fn({ properties: { val: 42 } })).toBe(true);
+    expect(fn({ properties: { val: 43 } })).toBe(false);
+    expect(fn({ properties: { val: '42' } })).toBe(true);
+  });
+
+  it('< works', () => {
+    const fn = buildFilterFn(col, { column: 'val', type: 'numeric', value: { type: 'comparison', operator: '<', value: 100 } });
+    expect(fn({ properties: { val: 99 } })).toBe(true);
+    expect(fn({ properties: { val: 100 } })).toBe(false);
+  });
+
+  it('<= works', () => {
+    const fn = buildFilterFn(col, { column: 'val', type: 'numeric', value: { type: 'comparison', operator: '<=', value: 100 } });
+    expect(fn({ properties: { val: 100 } })).toBe(true);
+  });
+
+  it('> works', () => {
+    const fn = buildFilterFn(col, { column: 'val', type: 'numeric', value: { type: 'comparison', operator: '>', value: 100 } });
+    expect(fn({ properties: { val: 101 } })).toBe(true);
+    expect(fn({ properties: { val: 100 } })).toBe(false);
+  });
+
+  it('>= works', () => {
+    const fn = buildFilterFn(col, { column: 'val', type: 'numeric', value: { type: 'comparison', operator: '>=', value: 100 } });
+    expect(fn({ properties: { val: 100 } })).toBe(true);
+  });
+});
+
+describe('buildFilterFn — text exact multi-select (autocomplete =)', () => {
+  const col: ColumnMeta = { name: 'state', type: 'text', uniqueValues: ['CA', 'NY', 'TX'] };
+  const info: FilterInfo = {
+    column: 'state',
+    type: 'text',
+    value: { type: 'multiple', values: ['CA', 'NY'], match: 'exact' },
+  };
+  const fn = buildFilterFn(col, info);
+
+  it('matches selected value (case-insensitive)', () => {
+    expect(fn({ properties: { state: 'CA' } })).toBe(true);
+    expect(fn({ properties: { state: 'ca' } })).toBe(true);
+  });
+
+  it('does not match unselected value', () => {
+    expect(fn({ properties: { state: 'TX' } })).toBe(false);
+  });
+
+  it('does substring matching only for contains (not exact)', () => {
+    // "California" should NOT match "CA" in exact mode
+    const caliCol: ColumnMeta = { name: 'state', type: 'text' };
+    const exactInfo: FilterInfo = { column: 'state', type: 'text', value: { type: 'multiple', values: ['CA'], match: 'exact' } };
+    const fnExact = buildFilterFn(caliCol, exactInfo);
+    expect(fnExact({ properties: { state: 'California' } })).toBe(false);
+  });
+});
+
+describe('buildFilterFn — text contains (substring, legacy)', () => {
+  const col: ColumnMeta = { name: 'name', type: 'text' };
+
+  it('case-insensitive substring match', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'multiple', values: ['chicago'] } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Chicago' } })).toBe(true);
+    expect(fn({ properties: { name: 'CHICAGO' } })).toBe(true);
+  });
+
+  it('does not match missing value', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'multiple', values: ['chicago'] } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Boston' } })).toBe(false);
+  });
+
+  it('backward-compat: no match field = substring', () => {
+    // Old config exports have `multiple` without `match` field
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'multiple', values: ['ill'] } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Illinois' } })).toBe(true);
+  });
+
+  it('OR semantics across multiple values', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'multiple', values: ['chicago', 'boston'] } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Chicago' } })).toBe(true);
+    expect(fn({ properties: { name: 'Boston' } })).toBe(true);
+    expect(fn({ properties: { name: 'Denver' } })).toBe(false);
+  });
+});
+
+describe('buildFilterFn — text comparison', () => {
+  const col: ColumnMeta = { name: 'name', type: 'text' };
+
+  it('= is case-insensitive', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'comparison', operator: '=', value: 'chicago' } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Chicago' } })).toBe(true);
+    expect(fn({ properties: { name: 'chicago' } })).toBe(true);
+    expect(fn({ properties: { name: 'Boston' } })).toBe(false);
+  });
+
+  it('< compares lexicographically', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'comparison', operator: '<', value: 'M' } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: 'Apple' } })).toBe(true);   // 'Apple' < 'M'
+    expect(fn({ properties: { name: 'Zebra' } })).toBe(false);  // 'Zebra' > 'M'
+  });
+});
+
+describe('buildFilterFn — edge cases', () => {
+  const col: ColumnMeta = { name: 'name', type: 'text' };
+
+  it('handles null value gracefully', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'comparison', operator: '=', value: 'chicago' } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: { name: null } })).toBe(false);
+  });
+
+  it('handles missing property gracefully', () => {
+    const info: FilterInfo = { column: 'name', type: 'text', value: { type: 'comparison', operator: '=', value: 'chicago' } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ properties: {} })).toBe(false);
+  });
+
+  it('handles raw object without .properties', () => {
+    // H3 wrapped items: filter receives raw properties via ?? fallback
+    const col: ColumnMeta = { name: 'state', type: 'text' };
+    const info: FilterInfo = { column: 'state', type: 'text', value: { type: 'multiple', values: ['CA'], match: 'exact' } };
+    const fn = buildFilterFn(col, info);
+    expect(fn({ state: 'CA' })).toBe(true);
+  });
+
+  it('return true for unknown value type', () => {
+    const badInfo = { column: 'x', type: 'text', value: {} } as unknown as FilterInfo;
+    const fn = buildFilterFn(col, badInfo);
+    expect(fn({ properties: { x: 'anything' } })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the text filter regression from the v2.3 redesign and adds project documentation.

### Bugs fixed
- **Text filter not working** — Text `=` was case-sensitive exact match with no autocomplete, meaning typed values rarely matched actual data. Fixed by adding autocomplete suggestion dropdown from column's unique values, and making text `=` case-insensitive.
- **applyConfig filter reconstruction** — Used `item.properties?.[col]` without the `?? item?.[col]` fallback, breaking imported filters for H3 and edge-case data shapes.

### What changed
- **FilterPanel** — Text `=` operator now shows an autocomplete dropdown as the user types. Arrow keys to navigate, Enter to pick. Selected values appear as removable chips. Multiple picks create OR semantics.
- **FilterInfo type** — Added optional `match: 'exact' | 'substring'` field to `multiple` value type (backward-compatible with existing config exports).
- **applyConfig** — Filter reconstruction now matches `buildFilterFn`'s access pattern.

### New documentation
- `docs/PRD.md` — Product requirements + feature completeness audit
- `docs/ARCHITECTURE.md` — Tech stack, state management, data flow, filter architecture
- `docs/TEST_PLAN.md` — Test inventory, coverage gaps, recommended additions
- `CLAUDE.md` — Updated doc index + current known issues

### Tests
- 36 new filter unit tests added (`src/utils/__tests__/filter.test.ts`)
- Total: 93 passing (up from 57)
- `yarn build` — 0 errors, `yarn lint` — 0 errors